### PR TITLE
Change make and model field in CarDTO to allow for numbers

### DIFF
--- a/src/main/java/com/revature/models/CarDTO.java
+++ b/src/main/java/com/revature/models/CarDTO.java
@@ -21,11 +21,11 @@ public class CarDTO {
 	private int seats;
 
 	@NotBlank(message = "Car make cannot be blank.")
-	@Pattern(regexp = "[a-zA-Z ]+", message = "A car's make may only contain letters and spaces.")
+	@Pattern(regexp = "[a-zA-Z0-9 ]+", message = "A car's make may only contain letters, numbers, and spaces.")
 	private String make;
 
 	@NotBlank(message = "Car model cannot be blank.")
-	@Pattern(regexp = "[a-zA-Z ]+", message = "A car's model may only contain letters and spaces.")
+	@Pattern(regexp = "[a-zA-Z0-9 ]+", message = "A car's model may only contain letters, numbers, and spaces.")
 	private String model;
 
 	@Positive(message = "Car year must be a positive number.")


### PR DESCRIPTION
-Changed regex pattern in both "make" and "model" field in the CarDTO model to include numbers, there are many makes and models that have numbers in it as well
-Car component in the front end will not work unless these changes are made.
